### PR TITLE
Browser compatibility

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,5 +9,6 @@ module.exports = {
     'prefer-named-capture-group': 'off',
     'semi': ['error', 'always'],
     'semi-style': ['error', 'last'],
+    'n/prefer-global/buffer': ['error', 'always'],
   },
 };

--- a/builder.js
+++ b/builder.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-params */
 import {
+  CURRENT_VERSION,
   DATA_BLOCK_LENGTH,
   DATA_GRANULARITY,
   DATA_MASK,
@@ -12,6 +13,7 @@ import {
   LSCP_INDEX_2_OFFSET,
   MAX_INDEX_1_LENGTH,
   OMITTED_BMP_INDEX_1_LENGTH,
+  PREFIX_LENGTH,
   SHIFT_1,
   SHIFT_1_2,
   SHIFT_2,
@@ -1154,14 +1156,15 @@ export class UnicodeTrieBuilder {
     const compressedValues = gzipSync(values, {level: 9});
 
     const arr = new Uint8Array(
-      12 + compressed.length + compressedValues.length
+      PREFIX_LENGTH + compressed.length + compressedValues.length
     );
     const dv = new DataView(arr.buffer);
     dv.setUint32(0, trie.highStart, true);
     dv.setUint32(4, trie.errorValue, true);
-    dv.setUint32(8, compressed.length, true);
-    arr.set(compressed, 12);
-    arr.set(compressedValues, 12 + compressed.length);
+    dv.setUint32(8, CURRENT_VERSION, true);
+    dv.setUint32(12, compressed.length, true);
+    arr.set(compressed, PREFIX_LENGTH);
+    arr.set(compressedValues, PREFIX_LENGTH + compressed.length);
 
     return arr;
   }

--- a/constants.js
+++ b/constants.js
@@ -61,3 +61,11 @@ export const MAX_INDEX_1_LENGTH = 0x100000 >> SHIFT_1;
 
 // The alignment size of a data block. Also the granularity for compaction.
 export const DATA_GRANULARITY = 1 << INDEX_SHIFT;
+
+// This goes in the third u32 of the input to show that we are decoding with
+// the same format the input was encoded with.  Could theoretically decrement
+// this for every major format change.
+export const CURRENT_VERSION = 0xFFFFFFFF;
+
+// Number of bytes before compressed data starts in this CURRENT_VERSION.
+export const PREFIX_LENGTH = 16;

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ export class UnicodeTrie {
   /**
    * Creates a trie, either from compressed data or pre-parsed values.
    *
-   * @param {Buffer|Uint8Array|TrieValues} data
+   * @param {Uint8Array|TrieValues} data
    */
   constructor(data) {
     if (data instanceof Uint8Array) {
@@ -74,6 +74,8 @@ export class UnicodeTrie {
    * @returns {UnicodeTrie} The decoded Unicode trie.
    */
   static fromBase64(base64) {
+    // This use of Buffer is ok unless we're using Parcel or some other
+    // packer that polyfills automatically.
     if (typeof Buffer === 'function') {
       return new UnicodeTrie(new Uint8Array(Buffer.from(base64, 'base64')));
     }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   ],
   "author": "Devon Govett <devongovett@gmail.com>",
   "contributors": [
-    "Joe Hildebrand <joe-github@cursive.net>"
+    "Joe Hildebrand <joe-github@cursive.net>",
+    "valadaptive <valadaptive@protonmail.com>"
   ],
   "repository": "cto-af/unicode-trie",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   "license": "MIT",
   "devDependencies": {
     "@cto.af/eslint-config": "3.1.0",
-    "@types/node": "20.11.24",
+    "@types/node": "20.11.25",
     "c8": "9.1.0",
     "eslint": "8.57.0",
     "mocha": "10.3.0",
-    "typescript": "5.3.3"
+    "typescript": "5.4.2"
   },
   "packageManager": "pnpm@8.15.4",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   "packageManager": "pnpm@8.15.4",
   "engines": {
     "node": ">=18"
+  },
+  "dependencies": {
+    "fflate": "^0.8.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,10 +12,10 @@ dependencies:
 devDependencies:
   '@cto.af/eslint-config':
     specifier: 3.1.0
-    version: 3.1.0(eslint@8.57.0)(typescript@5.3.3)
+    version: 3.1.0(eslint@8.57.0)(typescript@5.4.2)
   '@types/node':
-    specifier: 20.11.24
-    version: 20.11.24
+    specifier: 20.11.25
+    version: 20.11.25
   c8:
     specifier: 9.1.0
     version: 9.1.0
@@ -26,8 +26,8 @@ devDependencies:
     specifier: 10.3.0
     version: 10.3.0
   typescript:
-    specifier: 5.3.3
-    version: 5.3.3
+    specifier: 5.4.2
+    version: 5.4.2
 
 packages:
 
@@ -40,7 +40,7 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@cto.af/eslint-config@3.1.0(eslint@8.57.0)(typescript@5.3.3):
+  /@cto.af/eslint-config@3.1.0(eslint@8.57.0)(typescript@5.4.2):
     resolution: {integrity: sha512-cKYOpadawygA4jQZdXTPRB66MmoEIwwwPKObD4xxti6AWP5e5ck98jpyrUd8F2/3Sz4ckzZRenWixRF5/Wcc4g==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -62,10 +62,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@stylistic/eslint-plugin': 1.5.4(eslint@8.57.0)(typescript@5.3.3)
+      '@stylistic/eslint-plugin': 1.5.4(eslint@8.57.0)(typescript@5.4.2)
       eslint: 8.57.0
       eslint-plugin-n: 16.6.2(eslint@8.57.0)
-      typescript: 5.3.3
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -193,33 +193,33 @@ packages:
       estraverse: 5.3.0
     dev: true
 
-  /@stylistic/eslint-plugin-plus@1.5.4(eslint@8.57.0)(typescript@5.3.3):
+  /@stylistic/eslint-plugin-plus@1.5.4(eslint@8.57.0)(typescript@5.4.2):
     resolution: {integrity: sha512-dI0Cs5vYX/0uMhQDY+NK0cKQ0Pe9B6jWYxd0Ndud+mNloDaVLrsmJocK4zn+YfhGEDs1E4Nk5uAPZEumIpDuSg==}
     peerDependencies:
       eslint: '*'
     dependencies:
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.4.2)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@stylistic/eslint-plugin-ts@1.5.4(eslint@8.57.0)(typescript@5.3.3):
+  /@stylistic/eslint-plugin-ts@1.5.4(eslint@8.57.0)(typescript@5.4.2):
     resolution: {integrity: sha512-NZDFVIlVNjuPvhT+0Cidm5IS3emtx338xbJTqs2xfOVRDGTpYwRHhNVEGa1rFOpYHmv0sAj6+OXbMDn7ul0K/g==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: '>=8.40.0'
     dependencies:
       '@stylistic/eslint-plugin-js': 1.5.4(eslint@8.57.0)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.4.2)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@stylistic/eslint-plugin@1.5.4(eslint@8.57.0)(typescript@5.3.3):
+  /@stylistic/eslint-plugin@1.5.4(eslint@8.57.0)(typescript@5.4.2):
     resolution: {integrity: sha512-zWPXr+O67GC9KDAFkbL1U9UVqE6Iv69YMKhkIECCmE0GvClUJwdfsimm4XebEDondV7kfjMrTDZaYfrI5aS0Jg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -227,8 +227,8 @@ packages:
     dependencies:
       '@stylistic/eslint-plugin-js': 1.5.4(eslint@8.57.0)
       '@stylistic/eslint-plugin-jsx': 1.5.4(eslint@8.57.0)
-      '@stylistic/eslint-plugin-plus': 1.5.4(eslint@8.57.0)(typescript@5.3.3)
-      '@stylistic/eslint-plugin-ts': 1.5.4(eslint@8.57.0)(typescript@5.3.3)
+      '@stylistic/eslint-plugin-plus': 1.5.4(eslint@8.57.0)(typescript@5.4.2)
+      '@stylistic/eslint-plugin-ts': 1.5.4(eslint@8.57.0)(typescript@5.4.2)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
@@ -243,8 +243,8 @@ packages:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
     dev: true
 
-  /@types/node@20.11.24:
-    resolution: {integrity: sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==}
+  /@types/node@20.11.25:
+    resolution: {integrity: sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -266,7 +266,7 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.21.0(typescript@5.3.3):
+  /@typescript-eslint/typescript-estree@6.21.0(typescript@5.4.2):
     resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -282,13 +282,13 @@ packages:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.6.0
-      ts-api-utils: 1.2.1(typescript@5.3.3)
-      typescript: 5.3.3
+      ts-api-utils: 1.2.1(typescript@5.4.2)
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@6.21.0(eslint@8.57.0)(typescript@5.3.3):
+  /@typescript-eslint/utils@6.21.0(eslint@8.57.0)(typescript@5.4.2):
     resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -299,7 +299,7 @@ packages:
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.2)
       eslint: 8.57.0
       semver: 7.6.0
     transitivePeerDependencies:
@@ -1384,13 +1384,13 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /ts-api-utils@1.2.1(typescript@5.3.3):
+  /ts-api-utils@1.2.1(typescript@5.4.2):
     resolution: {integrity: sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==}
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.3.3
+      typescript: 5.4.2
     dev: true
 
   /type-check@0.4.0:
@@ -1405,8 +1405,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /typescript@5.3.3:
-    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+  /typescript@5.4.2:
+    resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+dependencies:
+  fflate:
+    specifier: ^0.8.2
+    version: 0.8.2
+
 devDependencies:
   '@cto.af/eslint-config':
     specifier: 3.1.0
@@ -728,6 +733,10 @@ packages:
     dependencies:
       reusify: 1.0.4
     dev: true
+
+  /fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+    dev: false
 
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}

--- a/test/swap.test.js
+++ b/test/swap.test.js
@@ -1,9 +1,8 @@
-import {Buffer} from 'node:buffer';
 import assert from 'node:assert';
 import {swap32} from '../swap.js';
 
 it('swaps 32bit words', () => {
-  const buf = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+  const buf = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
   swap32(buf);
-  assert.equal(buf.toString('hex'), '0403020108070605');
+  assert.deepEqual(buf, new Uint8Array([4, 3, 2, 1, 8, 7, 6, 5]));
 });

--- a/test/test.js
+++ b/test/test.js
@@ -82,9 +82,9 @@ describe('unicode trie', () => {
 
     const buf = trie.toBuffer();
     const bufferExpected = new Uint8Array([
-      0, 72, 0, 0, 0, 0, 0, 0, 83, 0, 0, 0,
+      0, 72, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 83, 0, 0, 0,
     ]);
-    assert.deepEqual(buf.subarray(0, 12), bufferExpected);
+    assert.deepEqual(buf.subarray(0, 16), bufferExpected);
   });
 
   it('should work with compressed serialization format', () => {
@@ -309,20 +309,20 @@ describe('unicode trie', () => {
 
 // Unicode 15.1, fflate compressed
 const EastAsianWidthNew = `\
-AAAEAAAAAAC1AgAAH4sIAALJ6GUCA+2aP0gfMRTHz59tqbUUuhQKHVpoKXRxKg4OCi6Ki6A4
-CC7iJE7iJCKIOCgKgrg5iLrpppujkzgoqJOgLuKgg+giCOI3mpN43P0u5y8vyXnvBx+Sy7+X
-vHtJXi6/5VIQrIJ1sAnC5yKFTDL7CqyPYnBksK1jcJaQd1Fh21fgVsbvQXV1EHwAX8A38AP8
-Bv9AHRDl/iNskHEbNEtZbZZkdkBOOF+7lXiUXuTtyng/4oOy7ECkzjCeR5W0cSU+hbioK+Kz
-ZWQxDGOWuP2ZYRiGYRiGYfLGvDxHLlg8o+uyQtAnfucMwzD2KHm4tzAM4/f9ZyXfaalYk/c4
-Gwg3Y9a18F5HRdzZbIEdD9bBz7VPTH9yQ1OQncWPQTBX9cQp4j9rXua34nkykhZlG/k1kB+2
-44JWD+QXem0p+J3pocd9E/fjj/+FKLiveKJpo+codwluMtr0QQ50cJdgA8G7+PT3kfRaPItx
-fkX4PaaO0MMvpIvwL8Lwfxt1iNfLdLFnN8q4SpNMa0HYDrrAtdLnHqVOp5QdPvfheSBhDCG3
-Gva/B4bQzp+Y/kV9oBGUGQMTYAbMp8h/Cz5gnhF2tVSqeoZ//CvyT8wAl+j20ZVeTJc18Y6S
-dONqNaMcf9a2KeyPUm9U9UyOr1xbunLK1afQgdqvuLJZ5k1SfQr7obbJNJ2k6c30euZSX7bn
-P4XNpNm2L/s/lSxf/J08+Fs+9cGVTkzKM9GWbdu1LcPlXM/LechF/22Mv9L20s4+NvRGka+r
-b518inHb9Glcz/vX6DyprA9+f5LtmfjWQLFe+PCth0L2a/wtV/uVi/nt8zt1eZ6hlG167afy
-F/P0Lnw+V5ne+2zu1S6/+Wf1l3X2X905aNr3cnlec+HfU+1/vq3xVOuyaf/c9JrxAKGklNHg
-SQAAH4sIAALJ6GUCA4tW8lPSUYpUigUA0d8CLAkAAAA=`;
+AAAEAAAAAAD/////tQIAAB+LCAAC0uhlAgPtmj9IHzEUx8+fbam1FLoUCh1aaCl0cSoODgou
+iougOAgu4iRO4iQiiDgoCoK4OYi66aabo5M4KKiToC7ioIPoIgjiN5qTeNz9LucvL8l57wcf
+ksu/l7x7SV4uv+VSEKyCdbAJwucihUwy+wqsj2JwZLCtY3CWkHdRYdtX4FbG70F1dRB8AF/A
+N/AD/Ab/QB0Q5f4jbJBxGzRLWW2WZHZATjhfu5V4lF7k7cp4P+KDsuxApM4wnkeVtHElPoW4
+qCvis2VkMQxjlrj9mWEYhmEYhmHyxrw8Ry5YPKPrskLQJ37nDMMw9ih5uLcwDOP3/Wcl32mp
+WJP3OBsIN2PWtfBeR0Xc2WyBHQ/Wwc+1T0x/ckNTkJ3Fj0EwV/XEKeI/a17mt+J5MpIWZRv5
+NZAftuOCVg/kF3ptKfid6aHHfRP344//hSi4r3iiaaPnKHcJbjLa9EEOdHCXYAPBu/j095H0
+WjyLcX5F+D2mjtDDL6SL8C/C8H8bdYjXy3SxZzfKuEqTTGtB2A66wLXS5x6lTqeUHT734Xkg
+YQwhtxr2vweG0M6fmP5FfaARlBkDE2AGzKfIfws+YJ4RdrVUqnqGf/wr8k/MAJfo9tGVXkyX
+NfGOknTjajWjHH/Wtinsj1JvVPVMjq9cW7pyytWn0IHar7iyWeZNUn0K+6G2yTSdpOnN9Hrm
+Ul+25z+FzaTZti/7P5UsX/ydPPhbPvXBlU5MyjPRlm3btS3D5VzPy3nIRf9tjL/S9tLOPjb0
+RpGvq2+dfIpx2/RpXM/71+g8qawPfn+S7Zn41kCxXvjwrYdC9mv8LVf7lYv57fM7dXmeoZRt
+eu2n8hfz9C58PleZ3vts7tUuv/ln9Zd19l/dOWja93J5XnPh31Ptf76t8VTrsmn/3PSa8QCh
+pJTR4EkAAB+LCAAC0uhlAgOLVvJT0lGKVIoFANHfAiwJAAAA`;
 
 // Unicode 15.1, brotli-compressed
 const EastAsianWidthOld = `\
@@ -351,10 +351,17 @@ describe('compatibility', () => {
     assert.equal(trie.get(0x3000), 1);
     globalThis.Buffer = buf;
   });
+
   it('rejects old versions', () => {
     assert.throws(
       () => UnicodeTrie.fromBase64(EastAsianWidthOld),
-      /Error: invalid gzip data/
+      /Trie created with old version of @cto.af\/unicode-trie\./
     );
+  });
+
+  it('rejects malformed inputs', () => {
+    assert.throws(() => new UnicodeTrie(new Uint8Array([
+      0, 72, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255,
+    ])), /RangeError: Invalid input length/);
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -306,3 +306,55 @@ describe('unicode trie', () => {
     assert.match(m, /export const Foo/);
   });
 });
+
+// Unicode 15.1, fflate compressed
+const EastAsianWidthNew = `\
+AAAEAAAAAAC1AgAAH4sIAALJ6GUCA+2aP0gfMRTHz59tqbUUuhQKHVpoKXRxKg4OCi6Ki6A4
+CC7iJE7iJCKIOCgKgrg5iLrpppujkzgoqJOgLuKgg+giCOI3mpN43P0u5y8vyXnvBx+Sy7+X
+vHtJXi6/5VIQrIJ1sAnC5yKFTDL7CqyPYnBksK1jcJaQd1Fh21fgVsbvQXV1EHwAX8A38AP8
+Bv9AHRDl/iNskHEbNEtZbZZkdkBOOF+7lXiUXuTtyng/4oOy7ECkzjCeR5W0cSU+hbioK+Kz
+ZWQxDGOWuP2ZYRiGYRiGYfLGvDxHLlg8o+uyQtAnfucMwzD2KHm4tzAM4/f9ZyXfaalYk/c4
+Gwg3Y9a18F5HRdzZbIEdD9bBz7VPTH9yQ1OQncWPQTBX9cQp4j9rXua34nkykhZlG/k1kB+2
+44JWD+QXem0p+J3pocd9E/fjj/+FKLiveKJpo+codwluMtr0QQ50cJdgA8G7+PT3kfRaPItx
+fkX4PaaO0MMvpIvwL8Lwfxt1iNfLdLFnN8q4SpNMa0HYDrrAtdLnHqVOp5QdPvfheSBhDCG3
+Gva/B4bQzp+Y/kV9oBGUGQMTYAbMp8h/Cz5gnhF2tVSqeoZ//CvyT8wAl+j20ZVeTJc18Y6S
+dONqNaMcf9a2KeyPUm9U9UyOr1xbunLK1afQgdqvuLJZ5k1SfQr7obbJNJ2k6c30euZSX7bn
+P4XNpNm2L/s/lSxf/J08+Fs+9cGVTkzKM9GWbdu1LcPlXM/LechF/22Mv9L20s4+NvRGka+r
+b518inHb9Glcz/vX6DyprA9+f5LtmfjWQLFe+PCth0L2a/wtV/uVi/nt8zt1eZ6hlG167afy
+F/P0Lnw+V5ne+2zu1S6/+Wf1l3X2X905aNr3cnlec+HfU+1/vq3xVOuyaf/c9JrxAKGklNHg
+SQAAH4sIAALJ6GUCA4tW8lPSUYpUigUA0d8CLAkAAAA=`;
+
+// Unicode 15.1, brotli-compressed
+const EastAsianWidthOld = `\
+AAAEAAAAAABQAgAAG99JMB6Jsa2CPeYryr2sfj99GygBKkJSf6IyVUDkyleXutZFVhEqYAoA
+mJtrCtRv0ZrqSbitMeeLQiLoCh3hSuDeR5eMedj/slD10Y0R5iZ4+1ElV2MAzTz7ie96VxgM
+BoNCIFAIDAKBQiFQGMxQI8EMpKCeSXI0syhuvoVSwY4LVLCPs8kIN7NFeMQnCP+GjwxUoAMj
+WMEBrmOpccOHwuuBEDTEyKsphJvIPvu382JWAW5AzGWi59pyqq/JBkL7AAd6X0lutmWoXTK8
+jsjwhoAZJtQw4MSUXienlP8GngeVYoXLhKPpn04ds0TKLcS+/L9zzLE4iZ7Sb4+w85UVDsyg
+8c3APOBwzY6Po64NSwzM3jzeUfk3MNAepfJMo6KX2/yfptV2McXQ0c6pKaP7H0DHF9wCL2LA
+VpoRrvPjw+JMsFaoUXSrAnX1xaZnLg2yNZtBrnpYAUeAA4EeR5pISE8+6yfznmtTJd4rBUSh
+Ldz0MwSs1VWmteyH40rrGprQhSGL0EL41q07Vp3scFtX1QxMl6kCS6s6iRLFngIY4zQBuAm3
+iesqIJrwHuAuIdQEG3mAAXfFAnIa/rPEfFOMA1xncd81oA89/JMZ3XP+FLBSKg3FUOLPLpUA
+u53UYL1UHlPJOKMn20b8A2OVN5LoVDAfwnL8t/KhRIdlBmjyhnoCxO2HJTDqLN2BuIRqOWjz
+3FoN8fSiXC6+0EnqSiK028ZajciD2V3UhLc0/o1FsII8qw3w1DgGjoNkBjrNMoxlu/GnvnVL
+yNjUsU0v3smU+gsEgFsiTiIsIlkiXQM=`;
+
+describe('compatibility', () => {
+  it('reads the current format from base64', () => {
+    const trie = UnicodeTrie.fromBase64(EastAsianWidthNew);
+    assert.equal(trie.get(0x3000), 1);
+  });
+  it('reads the current format from base64 without Buffer', () => {
+    const buf = globalThis.Buffer;
+    globalThis.Buffer = {};
+    const trie = UnicodeTrie.fromBase64(EastAsianWidthNew);
+    assert.equal(trie.get(0x3000), 1);
+    globalThis.Buffer = buf;
+  });
+  it('rejects old versions', () => {
+    assert.throws(
+      () => UnicodeTrie.fromBase64(EastAsianWidthOld),
+      /Error: invalid gzip data/
+    );
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -80,11 +80,11 @@ describe('unicode trie', () => {
     const trie = new UnicodeTrieBuilder();
     trie.set(0x4567, 99);
 
-    const buf = Buffer.from(trie.toBuffer());
-    const bufferExpected = Buffer.from([
+    const buf = trie.toBuffer();
+    const bufferExpected = new Uint8Array([
       0, 72, 0, 0, 0, 0, 0, 0, 83, 0, 0, 0,
     ]);
-    assert.equal(buf.subarray(0, 12).toString('hex'), bufferExpected.toString('hex'));
+    assert.deepEqual(buf.subarray(0, 12), bufferExpected);
   });
 
   it('should work with compressed serialization format', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,10 @@
 /* eslint-disable @stylistic/max-len */
 /* eslint-disable @stylistic/no-multi-spaces */
 /* eslint-disable prefer-destructuring */
-import {Buffer} from 'node:buffer';
 import {UnicodeTrie} from '../index.js';
 import {UnicodeTrieBuilder} from '../builder.js';
 import assert from 'node:assert';
-import {brotliCompressSync} from 'node:zlib';
+import {gzipSync} from 'fflate';
 
 describe('unicode trie', () => {
   it('set', () => {
@@ -81,9 +80,9 @@ describe('unicode trie', () => {
     const trie = new UnicodeTrieBuilder();
     trie.set(0x4567, 99);
 
-    const buf = trie.toBuffer();
+    const buf = Buffer.from(trie.toBuffer());
     const bufferExpected = Buffer.from([
-      0, 72, 0, 0, 0, 0, 0, 0, 62, 0, 0, 0,
+      0, 72, 0, 0, 0, 0, 0, 0, 83, 0, 0, 0,
     ]);
     assert.equal(buf.subarray(0, 12).toString('hex'), bufferExpected.toString('hex'));
   });
@@ -120,7 +119,7 @@ describe('unicode trie', () => {
   it('should handle the old format without string map', () => {
     const t = new UnicodeTrieBuilder(1);
     const buf = t.toBuffer();
-    const strings = brotliCompressSync(JSON.stringify([]));
+    const strings = gzipSync(JSON.stringify([]));
     const trie = new UnicodeTrie(buf.subarray(0, buf.length - strings.length));
     assert.equal(trie.get(13), 1);
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,9 +25,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "ES2020",                                /* Specify what module code is generated. */
+    "module": "NodeNext",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "NodeNext",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/types/builder.d.ts
+++ b/types/builder.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 export class UnicodeTrieBuilder {
     /**
      * Create a builder.  Ideally this is called from tooling at build time,
@@ -69,7 +68,7 @@ export class UnicodeTrieBuilder {
      */
     freeze(): UnicodeTrie;
     /**
-     * Generates a Buffer containing the serialized and compressed trie.
+     * Generates a Uint8Array containing the serialized and compressed trie.
      * Trie data is compressed using the brotli algorithm to minimize file size.
      * Format:
      *   uint32_t highStart;
@@ -77,9 +76,9 @@ export class UnicodeTrieBuilder {
      *   uint32_t compressedDataLength;
      *   uint8_t trieData[compressedDataLength];
      *   uint8_t compressedJSONstringValuesArray[];
-     * @returns {Buffer}
+     * @returns {Uint8Array}
      */
-    toBuffer(): Buffer;
+    toBuffer(): Uint8Array;
     /**
      * @typedef {object} ModuleOptions
      * @prop {string=} [version] Version of the source file, usually the Unicode
@@ -133,4 +132,3 @@ export class UnicodeTrieBuilder {
     #private;
 }
 import { UnicodeTrie } from './index.js';
-import { Buffer } from 'node:buffer';

--- a/types/constants.d.ts
+++ b/types/constants.d.ts
@@ -15,3 +15,5 @@ export const UTF8_2B_INDEX_2_LENGTH: number;
 export const INDEX_1_OFFSET: number;
 export const MAX_INDEX_1_LENGTH: number;
 export const DATA_GRANULARITY: number;
+export const CURRENT_VERSION: 4294967295;
+export const PREFIX_LENGTH: 16;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,10 @@
-/// <reference types="node" />
 export class UnicodeTrie {
+    /**
+     * Creates a trie from a base64-encoded string.
+     * @param {string} base64 The base64-encoded trie to initialize.
+     * @returns {UnicodeTrie} The decoded Unicode trie.
+     */
+    static fromBase64(base64: string): UnicodeTrie;
     /**
      * @typedef {object} TrieValues
      * @prop {Int32Array} data
@@ -8,11 +13,11 @@ export class UnicodeTrie {
      * @prop {string[]} [values]
      */
     /**
-     * Createa a trie, either from compressed data or pre-parsed values.
+     * Creates a trie, either from compressed data or pre-parsed values.
      *
-     * @param {Buffer|Uint8Array|TrieValues} data
+     * @param {Uint8Array|TrieValues} data
      */
-    constructor(data: Uint8Array | Buffer | {
+    constructor(data: Uint8Array | {
         data: Int32Array;
         highStart: number;
         errorValue: number;
@@ -44,4 +49,3 @@ export class UnicodeTrie {
      */
     getString(codePoint: number): number | string;
 }
-import { Buffer } from 'node:buffer';


### PR DESCRIPTION
Resolves #11.

This should allow this package to run in the browser, at the expense of some compression efficiency. It replaces `Buffer` with equivalent typed array methods and some custom ones for base64 en/decoding, and replaces `node:zlib` with `fflate` (there doesn't seem to be a good zopfli library, unfortunately).

Replacing the compression algorithm makes this a breaking change.